### PR TITLE
feat(adrs): Provide ADR capture and management capabilities #4

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adr

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Loglet
+
+## Resources
+
+### Architectural Decision Records
+
+* Architectural Decision Records <https://adr.github.io>
+* adrs <https://github.com/joshrotenberg/adrs>
+* When Should I Write an Architecture Decision Record <https://engineering.atspotify.com/2020/04/when-should-i-write-an-architecture-decision-record>
+* ADR Process <https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html#contents>

--- a/devbox.json
+++ b/devbox.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.15.1/.schema/devbox.schema.json",
+  "name": "loglet",
   "packages": [
-    "git@2.50.1"
+    "git@2.50.1",
+    "adrs@0.3.0"
   ]
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,6 +1,54 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "adrs@0.3.0": {
+      "last_modified": "2025-07-28T17:09:23Z",
+      "resolved": "github:NixOS/nixpkgs/648f70160c03151bc2121d179291337ad6bc564b#adrs",
+      "source": "devbox-search",
+      "version": "0.3.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/cqi0907426fak9jjqxk90qp5b6qrijjx-adrs-0.3.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/cqi0907426fak9jjqxk90qp5b6qrijjx-adrs-0.3.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hxiz7ysk3cmvrwckfb84a6jm7k0s1y1r-adrs-0.3.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hxiz7ysk3cmvrwckfb84a6jm7k0s1y1r-adrs-0.3.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/v4l5vh150z0w1xlxg812dsbsbxb00rly-adrs-0.3.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/v4l5vh150z0w1xlxg812dsbsbxb00rly-adrs-0.3.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nvxnryh10cls4815a57nc46qk7wvpzh8-adrs-0.3.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nvxnryh10cls4815a57nc46qk7wvpzh8-adrs-0.3.0"
+        }
+      }
+    },
     "git@2.50.1": {
       "last_modified": "2025-08-12T09:17:37Z",
       "resolved": "github:NixOS/nixpkgs/372d9eeeafa5b15913201e2b92e8e539ac7c64d1#git",

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,21 @@
+# 1. Record architecture decisions
+
+Date: 2025-08-23
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).
+
+We are using [adrs](https://github.com/joshrotenberg/adrs) tooling in this repository. This [Rust](https://www.rust-lang.org/) based implementation of the lightweight ADR toolset has a [Nix package](https://www.nixhub.io/packages/adrs) is supported by the [devbox](https://www.jetify.com/devbox) development environment used in this repository.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,25 @@
+# Architecture Decision Records
+
+This document is the index of all Architecture Decision Records (ADRs) for this project.
+
+ADRs capture the significant architectural and technical decisions we’ve made, along with the context and reasoning behind them. They provide a shared memory for the team, so we don’t lose knowledge when people move on or when decisions fade from day-to-day discussion.
+
+For developers, the ADRs explain why the system is built the way it is and help avoid re-debating past decisions.
+
+For new maintainers, the ADRs serve as a guide to the project’s evolution: what choices were made, what alternatives were considered, and what trade-offs shaped the current architecture. This makes it easier to onboard quickly, contribute effectively, and understand where changes may have wider impact.
+
+The list below contains all ADRs, in the order they were introduced.
+
+* [1. Record architecture decisions](0001-record-architecture-decisions.md)
+
+This index will continue to grow as new ADRs are written and older ones are superseded.
+
+Decisions marked as Superseded remain here for historical traceability but should not be followed for new work. Instead, always refer to the most recent applicable ADR.
+
+For contributors and maintainers:
+
+* If you are making a significant architectural change, create a new ADR and link it here rather than editing old ones.
+* If an ADR no longer reflects reality, mark it as Superseded and reference the new decision.
+* If you are new to the project, reviewing this index is the best way to understand the why behind the system’s current design.
+
+By maintaining this record, we ensure our architecture decisions remain transparent, traceable, and helpful for both today’s developers and tomorrow’s maintainers.

--- a/docs/adr/templates/intro.md
+++ b/docs/adr/templates/intro.md
@@ -1,0 +1,9 @@
+This document is the index of all Architecture Decision Records (ADRs) for this project.
+
+ADRs capture the significant architectural and technical decisions we’ve made, along with the context and reasoning behind them. They provide a shared memory for the team, so we don’t lose knowledge when people move on or when decisions fade from day-to-day discussion.
+
+For developers, the ADRs explain why the system is built the way it is and help avoid re-debating past decisions.
+
+For new maintainers, the ADRs serve as a guide to the project’s evolution: what choices were made, what alternatives were considered, and what trade-offs shaped the current architecture. This makes it easier to onboard quickly, contribute effectively, and understand where changes may have wider impact.
+
+The list below contains all ADRs, in the order they were introduced.

--- a/docs/adr/templates/outro.md
+++ b/docs/adr/templates/outro.md
@@ -1,0 +1,11 @@
+This index will continue to grow as new ADRs are written and older ones are superseded.
+
+Decisions marked as Superseded remain here for historical traceability but should not be followed for new work. Instead, always refer to the most recent applicable ADR.
+
+For contributors and maintainers:
+
+* If you are making a significant architectural change, create a new ADR and link it here rather than editing old ones.
+* If an ADR no longer reflects reality, mark it as Superseded and reference the new decision.
+* If you are new to the project, reviewing this index is the best way to understand the why behind the system’s current design.
+
+By maintaining this record, we ensure our architecture decisions remain transparent, traceable, and helpful for both today’s developers and tomorrow’s maintainers.

--- a/docs/adr/templates/template.md
+++ b/docs/adr/templates/template.md
@@ -1,0 +1,28 @@
+# {{number}}. {{title}}
+
+Date: {{date}}
+
+## Status
+
+Proposed
+{{#each superseded}}
+{{this}}
+{{/each}}
+{{#each linked}}
+{{this}}
+{{/each}}
+
+## Context
+[Describe the background and the problem or challenge that led to this decision. Explain *why* this decision is necessary.]
+
+## Decision
+[Clearly state the architectural decision made. Explain *what* was decided and *how* it addresses the problem described in the Context.]
+
+## Consequences
+[Outline the positive and negative consequences of this decision. This includes potential trade-offs, impacts on other parts of the system, and implications for future development.]
+
+## Alternatives Considered (Optional)
+[If applicable, list and briefly describe other options that were considered and why they were not chosen.]
+
+## Related Links (Optional)
+[Provide links to relevant documentation, design documents, Jira tickets, or other related ADRs.]


### PR DESCRIPTION
Provide ADR capture and management capabilities via [adrs](https://github.com/joshrotenberg/adrs) lightweight tooling.

The ADR tooling is installed via the `devbox` package configuration and provided via the `adrs` CLI commands.

Configuration of the ADR tooling has been carried out to:

* Store the ADRs in the `docs/adr` folder, as per practice and convention
* Provide a default decision template based on, but expanding upon the [Nygard ADR template](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
* Provide an `intro` for the ADR `README` that outlines the purpose of the ADRs
* Provide an `outro` for the ADR `README` that outlines some rules for contributors and maintainers around ADR management
* Generate a ADR `README` in the `docs/adr` directory containing the `intro`, a list of existing ADRs and the `outro`

Have also provided some ADR resources that can be useful to contributors and maintainers new to the concept.

Closes #4