### PR TITLE
feat(cli): Initial `loglet` CLI command #7

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,7 @@
 {
   "recommendations": [
-    "jetpack-io.devbox"
+    "jetpack-io.devbox",
+    "golang.Go",
+    "ms-vscode.makefile-tools"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
   "editor.detectIndentation": false,
 
   // Optional: run tasks in Devbox automatically
-  "tasks.shell": "devbox shell"
+  "tasks.shell": "devbox shell",
+
+  // Optional: configure Makefile support
+  "makefile.configureOnOpen": false
 }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: build run
+.DEFAULT_GOAL := run
+
+build:
+	go build ./cmd/loglet
+
+run:
+	go run ./cmd/loglet --help

--- a/cmd/loglet/main.go
+++ b/cmd/loglet/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/petersellars/loglet/internal/cli"
+
+func main() {
+	cli.Execute()
+}

--- a/devbox.json
+++ b/devbox.json
@@ -3,6 +3,12 @@
   "name": "loglet",
   "packages": [
     "git@2.50.1",
-    "adrs@0.3.0"
-  ]
+    "adrs@0.3.0",
+    "go@1.24.5"
+  ],
+  "env": {
+    "GOPATH": "$HOME/go",
+    "GOBIN": "$GOPATH/bin",
+    "PATH": "$PATH:$GOBIN"
+  }
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -124,6 +124,54 @@
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
       "last_modified": "2025-08-13T10:51:09Z",
       "resolved": "github:NixOS/nixpkgs/d74de548348c46cf25cb1fcc4b74f38103a4590d?lastModified=1755082269&narHash=sha256-Ix7ALeaxv9tW4uBKWeJnaKpYZtZiX4H4Q%2FMhEmj4XYA%3D"
+    },
+    "go@1.24.5": {
+      "last_modified": "2025-07-28T17:09:23Z",
+      "resolved": "github:NixOS/nixpkgs/648f70160c03151bc2121d179291337ad6bc564b#go",
+      "source": "devbox-search",
+      "version": "1.24.5",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kw1vd98s15vj700m3gx2x2xca2z477i3-go-1.24.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kw1vd98s15vj700m3gx2x2xca2z477i3-go-1.24.5"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5bzlaj0c4mqw9p0zrcx5g9vz16vd45dl-go-1.24.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/5bzlaj0c4mqw9p0zrcx5g9vz16vd45dl-go-1.24.5"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/b72n20ixzl5ja9vciwahkr30bhmsn5jc-go-1.24.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/b72n20ixzl5ja9vciwahkr30bhmsn5jc-go-1.24.5"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/y4awwzp30ka130wmjrpaqjmjdf9p010w-go-1.24.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/y4awwzp30ka130wmjrpaqjmjdf9p010w-go-1.24.5"
+        }
+      }
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/petersellars/loglet
+
+go 1.24.5
+
+require github.com/spf13/cobra v1.9.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "loglet",
+	Short: "Fast, minimalist static blog generator",
+	Long:  "A fast, minimalist static blog generator that turns plain text into clean, timeless HTML in seconds",
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Provide the `loglet` CLI with a basic `--help` command provided by the [Cobra](https://github.com/spf13/cobra) library implementation.

* Golang developer environment configuration via the `devbox` configuration
* Go module configuration, with [Cobra](https://github.com/spf13/cobra) dependency
* Provide CLI via the loglet command
* Provide the CLI root command via the `cli` package
* Makefile supplied with initial `build` and `run` tasks

Some additional vscode settings and extensions to support Golang development and tooling.

Closes #7