### PR TITLE
chore(pipeline): Initial ability to continously build the loglet CLI #19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: ci
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.24.5'
+
+      - name: Cache Go Build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Go Build CLI
+        run: go build -o loglet ./cmd/loglet
+
+      - name: CLI Help
+        run: ./loglet --help

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-.PHONY: build run
+.PHONY: act-build adr-readme build run
 .DEFAULT_GOAL := run
+
+act-build:
+	act -j build -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04
+
+adr-readme:
+	adrs generate toc -i ./docs/adr/templates/intro.md -o ./docs/adr/templates/outro.md > ./docs/adr/README.md
 
 build:
 	go build ./cmd/loglet
 
 run:
 	go run ./cmd/loglet --help
-
-adr-readme:
-	adrs generate toc -i ./docs/adr/templates/intro.md -o ./docs/adr/templates/outro.md > ./docs/adr/README.md

--- a/devbox.json
+++ b/devbox.json
@@ -2,8 +2,10 @@
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.15.1/.schema/devbox.schema.json",
   "name": "loglet",
   "packages": [
-    "git@2.50.1",
+    "act@0.2.80",
     "adrs@0.3.0",
+    "docker@28.3.3",
+    "git@2.50.1",
     "go@1.24.5"
   ],
   "env": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,6 +1,54 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "act@0.2.80": {
+      "last_modified": "2025-08-08T08:05:48Z",
+      "resolved": "github:NixOS/nixpkgs/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1#act",
+      "source": "devbox-search",
+      "version": "0.2.80",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3rcyprhvrhvp5fzyddr2dxkf039dh936-act-0.2.80",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3rcyprhvrhvp5fzyddr2dxkf039dh936-act-0.2.80"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lldga7zpaxfl8pigvj9i42afhjzdwfwn-act-0.2.80",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/lldga7zpaxfl8pigvj9i42afhjzdwfwn-act-0.2.80"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vq9qdxbjilndz8mjja0fqlcxg8xad67j-act-0.2.80",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vq9qdxbjilndz8mjja0fqlcxg8xad67j-act-0.2.80"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ni84y2cl49l7fsmrq1d9njfgdk2j3bz9-act-0.2.80",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ni84y2cl49l7fsmrq1d9njfgdk2j3bz9-act-0.2.80"
+        }
+      }
+    },
     "adrs@0.3.0": {
       "last_modified": "2025-07-28T17:09:23Z",
       "resolved": "github:NixOS/nixpkgs/648f70160c03151bc2121d179291337ad6bc564b#adrs",
@@ -46,6 +94,54 @@
             }
           ],
           "store_path": "/nix/store/nvxnryh10cls4815a57nc46qk7wvpzh8-adrs-0.3.0"
+        }
+      }
+    },
+    "docker@28.3.3": {
+      "last_modified": "2025-08-08T08:05:48Z",
+      "resolved": "github:NixOS/nixpkgs/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1#docker",
+      "source": "devbox-search",
+      "version": "28.3.3",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6x679ch4cqa5aywjsrnplsasv5rp0mak-docker-28.3.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6x679ch4cqa5aywjsrnplsasv5rp0mak-docker-28.3.3"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/8jb799sr948h68avj9k3xkvznv10f470-docker-28.3.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/8jb799sr948h68avj9k3xkvznv10f470-docker-28.3.3"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/g3h7m6qsx5rkb908qcqi4a6kflvcriz5-docker-28.3.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/g3h7m6qsx5rkb908qcqi4a6kflvcriz5-docker-28.3.3"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/r0vqz3dsdhw31gyk098qgrw61vwmc7a1-docker-28.3.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/r0vqz3dsdhw31gyk098qgrw61vwmc7a1-docker-28.3.3"
         }
       }
     },

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ]
 }


### PR DESCRIPTION
* Initial GitHub Actions CI Workflow
  * Checkout, Set up Go, Cache Go Build, Build and Run using `--help` flag
* Update Renovate configuration to pin GitHub Action Digests
  * Uses `helpers:pinGitHubActionDigests`
* Add `act`, and `docker` to the Devbox configuration
  * Use `act` to test GitHub Actions locally
* Provide `act-build` task in Makefile
  * Use `act` locally to run GitHub Action for testing